### PR TITLE
Adjust Clock Hand Animation Speed for Realistic Timekeeping

### DIFF
--- a/Clock animation/s.css
+++ b/Clock animation/s.css
@@ -28,7 +28,7 @@ body{
   height: 6px;
   background: #262626;
   border-radius: 3px;
-  animation: animate 4s linear infinite;
+  animation: animate 60s linear infinite; /* Slower animation */
   transform-origin: left;
 }
 
@@ -42,7 +42,7 @@ body{
   height: 6px;
   background: #262626;
   border-radius: 3px;
-  animation: animate 48s linear infinite;
+  animation: animate 3600s linear infinite;  /* 60 minutes */
   transform-origin: left;
 }
 span
@@ -53,7 +53,7 @@ span
         left: 50%;
         transform: translate(-50%,-50%);
         width: 12px;
-        height: 10px;
+        height: 12px; /* Slightly larger circles */
         background: #ff5f5f;
         border-radius: 50%;
         z-index: 1;


### PR DESCRIPTION
Issue number - #54 
## Pull Request Summary

**Changes Made:**

In this PR, I have adjusted the animation speeds of the clock hands in the clock animation to achieve a more realistic and visually pleasing timekeeping experience. The changes include:

- Second Hand: Animation duration set to 60 seconds (1 minute per full rotation).
- Minute Hand: Animation duration set to 3600 seconds (1 hour per full rotation).

**Reasoning:**

The original animation speeds may have been too fast or not adequately reflective of the real clock movement. These adjustments aim to provide a more accurate and engaging clock animation, enhancing the user experience.